### PR TITLE
Exclude .DS_Store files from antaresplugins.

### DIFF
--- a/Archivers/Resource/ResArchiver.m
+++ b/Archivers/Resource/ResArchiver.m
@@ -169,7 +169,7 @@
         //zip it
         NSTask *zipTask = [[NSTask alloc] init];
         [zipTask setLaunchPath:@"/usr/bin/zip"];
-        [zipTask setArguments:[NSArray arrayWithObjects:@"-q", [file lastPathComponent], @"-r", @"./data/", nil]];
+        [zipTask setArguments:[NSArray arrayWithObjects:@"-q", [file lastPathComponent], @"-x", @".DS_Store", @"-r", @"./data/", nil]];
         [zipTask setCurrentDirectoryPath:[file stringByDeletingLastPathComponent]];
         [zipTask launch];
         [zipTask waitUntilExit];


### PR DESCRIPTION
Got a report from a user that generated antaresplugins had .DS_Store files, which Antares chokes on. I don't know how that could happen, but it's easy to make sure it doesn't.
