### PR TITLE
Bump version to 1.1

### DIFF
--- a/Athena-Info.plist
+++ b/Athena-Info.plist
@@ -74,7 +74,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
The 1.0 published on downloads.arescentral.org doesn’t have Antares
plugin support. I’ve published a new version, built from HEAD, as 1.1.